### PR TITLE
Fix benchmark

### DIFF
--- a/benchmarks/sergey/sat.sch
+++ b/benchmarks/sergey/sat.sch
@@ -26,6 +26,6 @@
                                 (try (lambda (n5)
                                        (try (lambda (n6)
                                               (try (lambda (n7)
-                                                     ((((((p n1) n2) n3) n4) n5) n6) n7))))))))))))))))
+                                                     (((((((p n1) n2) n3) n4) n5) n6) n7)))))))))))))))))
 
 (sat-solve-7 phi)


### PR DESCRIPTION
The last function in sat-solve-7’s body is:

```scheme
(lambda (n7)
  ((((((p n1) n2) n3) n4) n5) n6) n7)
```

Because of all the parentheses, it’s hard to see, but this is actually the following:

```scheme
(lambda (n7)
  ((((((p n1) n2) n3) n4) n5) n6)
  n7)
```

This function is applying the predicate `p` with only the first six arguments. Then it discards the result and outputs `n7`, as is. It’s a convoluted identity function!

The fix is to add yet more parenthesis:

```scheme
(lambda (n7)
  (((((((p n1) n2) n3) n4) n5) n6) n7))
```